### PR TITLE
Add a travis build to ensure compatibility with Ruby 2.5.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+rvm:
+  - 1.9.3
+  - 2.3.1
+  - 2.5.1
+
+matrix:
+  fast_finish: true
+  allow_failures:
+  - rvm: 1.9.3
+  - rvm: 2.5.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     metaclass (0.0.1)
+    minitest (5.10.3)
     mocha (0.13.3)
       metaclass (~> 0.0.1)
     rake (10.0.3)
@@ -16,6 +17,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 1.3)
+  minitest
   mocha
   rake
   style_palette!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    style_palette (0.0.1)
+    style_palette (0.0.8)
 
 GEM
   remote: https://rubygems.org/
@@ -16,8 +16,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.3)
+  bundler (~> 1.16.1)
   minitest
   mocha
   rake
   style_palette!
+
+BUNDLED WITH
+   1.16.1

--- a/lib/style_palette/version.rb
+++ b/lib/style_palette/version.rb
@@ -1,3 +1,3 @@
 module StylePalette
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end

--- a/style_palette.gemspec
+++ b/style_palette.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.16.1"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "minitest"

--- a/style_palette.gemspec
+++ b/style_palette.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha"
+  spec.add_development_dependency "minitest"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
-require "minitest/unit"
 require "minitest/autorun"
+require "minitest/unit"
 require "mocha/setup"
 
 require_relative "../lib/style_palette"


### PR DESCRIPTION
# What is that about ❓ 

This PR ensures that this gem can run on *ruby 2.5.1* while maintaining the compatibility with older versions.

## How about the travis stuff?

Here is the current build for rubies 1.9.3, 2.3.1, 2.5.1: https://travis-ci.org/mistersourcerer/StylePalette/builds/383221587.